### PR TITLE
fix: correct Wekan API endpoints and required parameters

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@ const BASE_URL = process.env["WEKAN_BASE_URL"]?.replace(/\/$/, "") || "";
 const TOKEN = process.env["WEKAN_API_TOKEN"] || "";
 const USERNAME = process.env["WEKAN_USERNAME"] || "";
 const PASSWORD = process.env["WEKAN_PASSWORD"] || "";
+const USER_ID = process.env["WEKAN_USER_ID"] || "";
 
 if (!BASE_URL || (!TOKEN && !(USERNAME && PASSWORD))) {
   // Fail fast so agent surfaces a clear error.
@@ -19,7 +20,8 @@ const wekan = new Wekan({
   baseUrl: BASE_URL, 
   token: TOKEN,
   username: USERNAME,
-  password: PASSWORD
+  password: PASSWORD,
+  userId: USER_ID
 });
 
 const server = new McpServer(
@@ -29,8 +31,7 @@ const server = new McpServer(
 
 // Register tools
 server.tool("listBoards", "List accessible Wekan boards", {}, async () => {
-  const boards = await wekan.listBoards();
-  // Return trimmed, agent-friendly fields
+  const boards = await wekan.listBoards(USER_ID);
   return { content: [{ type: "text", text: JSON.stringify(boards.map((b) => ({ id: b._id, title: b.title })))}] };
 });
 
@@ -64,15 +65,18 @@ server.tool("createCard", "Create a card", {
   listId: z.string(),
   title: z.string(),
   description: z.string().optional(),
-  swimlaneId: z.string().optional(),
+  swimlaneId: z.string(),
   due: z.string().datetime().optional(),
   members: z.array(z.string()).optional(),
   labels: z.array(z.string()).optional()
 }, async (args) => {
   const { boardId, listId, title, description, swimlaneId, due, members, labels } = args;
-  const body: any = { title };
-  if (description) body.description = description;
-  if (swimlaneId) body.swimlaneId = swimlaneId;
+  const body: any = {
+    authorId: USER_ID,
+    title,
+    description: description || "",
+    swimlaneId
+  };
   if (due) body.dueAt = due;
   if (members) body.members = members;
   if (labels) body.labelIds = labels;
@@ -82,25 +86,26 @@ server.tool("createCard", "Create a card", {
 
 server.tool("moveCard", "Move a card to another list or swimlane", {
   boardId: z.string(),
+  fromListId: z.string(),
   cardId: z.string(),
   listId: z.string().optional(),
   swimlaneId: z.string().optional()
 }, async (args) => {
-  const { boardId, cardId, listId, swimlaneId } = args;
+  const { boardId, fromListId, cardId, listId, swimlaneId } = args;
   const payload: any = {};
   if (listId) payload.listId = listId;
   if (swimlaneId) payload.swimlaneId = swimlaneId;
-  const card = await wekan.moveCard(boardId, cardId, payload);
+  const card = await wekan.moveCard(boardId, fromListId, cardId, payload);
   return { content: [{ type: "text", text: JSON.stringify({ id: card._id, listId: card.listId, swimlaneId: card.swimlaneId }) }] };
 });
 
 server.tool("commentCard", "Add a comment to a card", {
   boardId: z.string(),
   cardId: z.string(),
-  text: z.string().min(1)
+  comment: z.string().min(1)
 }, async (args) => {
-  const { boardId, cardId, text } = args;
-  const res = await wekan.commentCard(boardId, cardId, text);
+  const { boardId, cardId, comment } = args;
+  const res = await wekan.commentCard(boardId, cardId, USER_ID, comment);
   return { content: [{ type: "text", text: JSON.stringify({ ok: true, commentId: res._id }) }] };
 });
 

--- a/src/wekan.ts
+++ b/src/wekan.ts
@@ -12,6 +12,7 @@ export type WekanClientOpts = {
   token?: string;
   username?: string;
   password?: string;
+  userId?: string;
 };
 
 // Wekan API response types
@@ -121,11 +122,11 @@ export class Wekan {
   }
 
   // API surface
-  listBoards(): Promise<WekanBoard[]> { return this.get(`/api/boards`); }
+  listBoards(userId: string): Promise<WekanBoard[]> { return this.get(`/api/users/${userId}/boards`); }
   listLists(boardId: string): Promise<WekanList[]> { return this.get(`/api/boards/${boardId}/lists`); }
   listSwimlanes(boardId: string): Promise<WekanSwimlane[]> { return this.get(`/api/boards/${boardId}/swimlanes`); }
   listCards(boardId: string, listId: string): Promise<WekanCard[]> { return this.get(`/api/boards/${boardId}/lists/${listId}/cards`); }
   createCard(boardId: string, listId: string, body: any): Promise<WekanCard> { return this.post(`/api/boards/${boardId}/lists/${listId}/cards`, body); }
-  moveCard(boardId: string, cardId: string, body: any): Promise<WekanCard> { return this.put(`/api/boards/${boardId}/cards/${cardId}`, body); }
-  commentCard(boardId: string, cardId: string, text: string): Promise<WekanComment> { return this.post(`/api/boards/${boardId}/cards/${cardId}/comments`, { text }); }
+  moveCard(boardId: string, fromListId: string, cardId: string, body: any): Promise<WekanCard> { return this.put(`/api/boards/${boardId}/lists/${fromListId}/cards/${cardId}`, body); }
+  commentCard(boardId: string, cardId: string, authorId: string, comment: string): Promise<WekanComment> { return this.post(`/api/boards/${boardId}/cards/${cardId}/comments`, { authorId, comment }); }
 }


### PR DESCRIPTION
- Add WEKAN_USER_ID environment variable for user-specific operations
- Fix listBoards to use user-specific endpoint (/api/users/{userId}/boards)
- Fix createCard to require swimlaneId and include authorId
- Fix moveCard to include fromListId parameter in API path
- Fix commentCard to use 'comment' field and include authorId
- Update all API method signatures to match Wekan API requirements

These changes ensure proper integration with Wekan's actual API structure
and resolve issues with board listing, card creation, and card operations.